### PR TITLE
Perturbations and covariance sampling

### DIFF
--- a/include/cfear_radarodometry/n_scan_normal.h
+++ b/include/cfear_radarodometry/n_scan_normal.h
@@ -46,6 +46,8 @@ public:
 
   double getScore(){return score_;}
 
+  bool GetCovarianceScaler(double &cov_scale);
+
   void getScore(double& score, int& num_residuals){score = score_; num_residuals = problem_->NumResiduals();}
 
   void SetD2dPar(const double cov_scale,const double regularization){cov_scale_ = cov_scale; regularization_ = regularization;}

--- a/include/cfear_radarodometry/odometrykeyframefuser.h
+++ b/include/cfear_radarodometry/odometrykeyframefuser.h
@@ -27,9 +27,6 @@
 #include <time.h>
 #include <cstdio>
 
-//VK: random for playing with the perturbation
-#include <random>
-#include <algorithm>
 
 #include <pcl_ros/transforms.h>
 #include "pcl_ros/publisher.h"
@@ -221,9 +218,6 @@ protected:
   ros::Subscriber pointcloud_callback;
   ros::Publisher pose_current_publisher, pose_keyframe_publisher, pubsrc_cloud_latest, pub_cloud_keyframe;;
   tf::TransformBroadcaster Tbr;
-
-  //VK: Tools for perturbing the odometry
-  std::default_random_engine generator;
 
 
 

--- a/include/cfear_radarodometry/odometrykeyframefuser.h
+++ b/include/cfear_radarodometry/odometrykeyframefuser.h
@@ -27,6 +27,10 @@
 #include <time.h>
 #include <cstdio>
 
+//VK: random for playing with the perturbation
+#include <random>
+#include <algorithm>
+
 #include <pcl_ros/transforms.h>
 #include "pcl_ros/publisher.h"
 
@@ -51,6 +55,7 @@ using std::string;
 using std::cout;
 using std::cerr;
 using std::endl;
+
 
 
 
@@ -199,6 +204,9 @@ protected:
   ros::Publisher pose_current_publisher, pose_keyframe_publisher, pubsrc_cloud_latest, pub_cloud_keyframe;;
   tf::TransformBroadcaster Tbr;
 
+  //VK: Tools for perturbing the odometry
+  std::default_random_engine generator;
+
 
 
 public:
@@ -255,4 +263,8 @@ void FormatScans(const PoseScanVector& reference,
                  std::vector<Eigen::Affine3d>& T_vek
                  );
 
+template<typename T> std::vector<double> linspace(T start_in, T end_in, int num_in);
+
 }
+
+

--- a/include/cfear_radarodometry/odometrykeyframefuser.h
+++ b/include/cfear_radarodometry/odometrykeyframefuser.h
@@ -104,7 +104,7 @@ public:
     double covar_scale_ = 1.0;
     double regularization_ = 0.0;
 
-    bool estimate_cov_by_sampling = true;
+    bool estimate_cov_by_sampling = false;
     bool cov_samples_to_file_as_well = false; // Will save in the desired folder
     std::string cov_sampling_file_directory = "/tmp/cfear_out";
     double cov_sampling_xy_range = 0.4;  // Will sample from -0.2 to +0.2
@@ -264,6 +264,8 @@ private:
   void processFrame(pcl::PointCloud<pcl::PointXYZI>::Ptr& cloud_filtered, pcl::PointCloud<pcl::PointXYZI>::Ptr& cloud_peaks, const ros::Time& t);
 
   void pointcloudCallback(const sensor_msgs::PointCloud2::ConstPtr& cloud_filtered);
+
+  bool approximateCovarianceBySampling(std::vector<CFEAR_Radarodometry::MapNormalPtr> &scans_vek, const std::vector<Eigen::Affine3d> &T_vek, Covariance &cov_sampled);
 
 
 

--- a/include/cfear_radarodometry/odometrykeyframefuser.h
+++ b/include/cfear_radarodometry/odometrykeyframefuser.h
@@ -109,8 +109,8 @@ public:
     std::string cov_sampling_file_directory = "/tmp/cfear_out";
     double cov_sampling_xy_range = 0.4;  // Will sample from -0.2 to +0.2
     double cov_sampling_yaw_range = 0.0043625; //Will sample from -half to +half of this range as well
-    unsigned int cov_sampling_samples_per_axis = 5; //Will do 5^3 in the end
-    double cov_sampling_covariance_scaler = 1.0;
+    unsigned int cov_sampling_samples_per_axis = 3; //Will do 5^3 in the end
+    double cov_sampling_covariance_scaler = 4.0;
 
 
     bool publish_tf_ = true;
@@ -186,6 +186,13 @@ public:
       stringStream << "publish_tf, "<<std::boolalpha<<publish_tf_<<endl;
       stringStream << "store graph, "<<store_graph<<endl;
       stringStream << "Weight, "<<weight_opt<<endl;
+      stringStream << "Use cost sampling for covariance, "<<std::boolalpha<<estimate_cov_by_sampling<<endl;
+      stringStream << "Save cost samples to a file, "<<std::boolalpha<<cov_samples_to_file_as_well<<endl;
+      stringStream << "Cost-samples-file folder, "<<cov_sampling_file_directory<<endl;
+      stringStream << "XY sampling range, "<<cov_sampling_xy_range<<endl;
+      stringStream << "Yaw sampling range, "<<cov_sampling_yaw_range<<endl;
+      stringStream << "Cost samples per axis, "<<cov_sampling_samples_per_axis<<endl;
+      stringStream << "Sampled covariance scale, "<<cov_sampling_covariance_scaler<<endl;
       return stringStream.str();
     }
   };

--- a/include/cfear_radarodometry/odometrykeyframefuser.h
+++ b/include/cfear_radarodometry/odometrykeyframefuser.h
@@ -104,8 +104,19 @@ public:
     double covar_scale_ = 1.0;
     double regularization_ = 0.0;
 
+    bool estimate_cov_by_sampling = true;
+    bool cov_samples_to_file_as_well = false; // Will save in the desired folder
+    std::string cov_sampling_file_directory = "/tmp/cfear_out";
+    double cov_sampling_xy_range = 0.4;  // Will sample from -0.2 to +0.2
+    double cov_sampling_yaw_range = 0.0043625; //Will sample from -half to +half of this range as well
+    unsigned int cov_sampling_samples_per_axis = 5; //Will do 5^3 in the end
+    double cov_sampling_covariance_scaler = 1.0;
+
+
     bool publish_tf_ = true;
     bool store_graph = false;
+
+
 
     void GetParametersFromRos( ros::NodeHandle& param_nh){
       param_nh.param<std::string>("input_points_topic", input_points_topic, "/Navtech/Filtered");

--- a/include/cfear_radarodometry/types.h
+++ b/include/cfear_radarodometry/types.h
@@ -182,6 +182,10 @@ struct Constraint3d {
     ar & id_end;
     ar & t_be;
     ar & information;
+    ar & type;
+    ar & quality;
+    ar & info;
+
   }
 };
 

--- a/launch/kvarntorp/run_sequence_kvarntorp
+++ b/launch/kvarntorp/run_sequence_kvarntorp
@@ -69,8 +69,13 @@ export dataset="kvarntorp"
 export LOSS_TYPE="Huber"
 export LOSS_LIMIT="0.1"
 
+# COV SAMPLING PARS
+export covar_sampling="False"
+export covar_samples_per_axis="3"
+export covar_sampling_scale="4"
 
-pars="--range-res ${range_res} --sequence ${SEQUENCE} --radar_ccw ${radar_ccw} --soft_constraint ${soft_constraint} --disable_compensate ${disable_compensate} --cost_type ${cost_type} --submap_scan_size ${submap_scan_size} --registered_min_keyframe_dist ${registered_min_keyframe_dist} --res ${res} --k_strongest ${kstrong} --bag_path ${BAG_FILE_PATH} --est_directory ${est_dir} --gt_directory ${gt_dir} --job_nr 1 --z-min ${zmin} --loss_type ${LOSS_TYPE} --loss_limit ${LOSS_LIMIT}  --weight_intensity ${weight_intensity} --method ${EVALUATION_description} --weight_option ${weight_option} --dataset ${dataset}"
+
+pars="--range-res ${range_res} --sequence ${SEQUENCE} --radar_ccw ${radar_ccw} --soft_constraint ${soft_constraint} --disable_compensate ${disable_compensate} --cost_type ${cost_type} --submap_scan_size ${submap_scan_size} --registered_min_keyframe_dist ${registered_min_keyframe_dist} --res ${res} --k_strongest ${kstrong} --bag_path ${BAG_FILE_PATH} --est_directory ${est_dir} --gt_directory ${gt_dir} --job_nr 1 --z-min ${zmin} --loss_type ${LOSS_TYPE} --loss_limit ${LOSS_LIMIT}  --weight_intensity ${weight_intensity} --method ${EVALUATION_description} --weight_option ${weight_option} --dataset ${dataset} --store_graph true --covar_sampling ${covar_sampling} --covar_samples_per_axis ${covar_samples_per_axis} --covar_sampling_scale ${covar_sampling_scale}"
 echo "|||||Estimating odometry with parameters: ${pars}||||"
 roslaunch cfear_radarodometry vis.launch&
 rosrun cfear_radarodometry offline_odometry ${pars} #>/dev/null

--- a/launch/kvarntorp/run_sequence_kvarntorp
+++ b/launch/kvarntorp/run_sequence_kvarntorp
@@ -71,11 +71,8 @@ export LOSS_LIMIT="0.1"
 
 # COV SAMPLING PARS
 export covar_sampling="False"
-export covar_samples_per_axis="3"
-export covar_sampling_scale="4"
 
-
-pars="--range-res ${range_res} --sequence ${SEQUENCE} --radar_ccw ${radar_ccw} --soft_constraint ${soft_constraint} --disable_compensate ${disable_compensate} --cost_type ${cost_type} --submap_scan_size ${submap_scan_size} --registered_min_keyframe_dist ${registered_min_keyframe_dist} --res ${res} --k_strongest ${kstrong} --bag_path ${BAG_FILE_PATH} --est_directory ${est_dir} --gt_directory ${gt_dir} --job_nr 1 --z-min ${zmin} --loss_type ${LOSS_TYPE} --loss_limit ${LOSS_LIMIT}  --weight_intensity ${weight_intensity} --method ${EVALUATION_description} --weight_option ${weight_option} --dataset ${dataset} --store_graph true --covar_sampling ${covar_sampling} --covar_samples_per_axis ${covar_samples_per_axis} --covar_sampling_scale ${covar_sampling_scale}"
+pars="--range-res ${range_res} --sequence ${SEQUENCE} --radar_ccw ${radar_ccw} --soft_constraint ${soft_constraint} --disable_compensate ${disable_compensate} --cost_type ${cost_type} --submap_scan_size ${submap_scan_size} --registered_min_keyframe_dist ${registered_min_keyframe_dist} --res ${res} --k_strongest ${kstrong} --bag_path ${BAG_FILE_PATH} --est_directory ${est_dir} --gt_directory ${gt_dir} --job_nr 1 --z-min ${zmin} --loss_type ${LOSS_TYPE} --loss_limit ${LOSS_LIMIT}  --weight_intensity ${weight_intensity} --method ${EVALUATION_description} --weight_option ${weight_option} --dataset ${dataset} --store_graph true --covar_sampling ${covar_sampling}"
 echo "|||||Estimating odometry with parameters: ${pars}||||"
 roslaunch cfear_radarodometry vis.launch&
 rosrun cfear_radarodometry offline_odometry ${pars} #>/dev/null

--- a/launch/oxford/run_sequence_save_odom
+++ b/launch/oxford/run_sequence_save_odom
@@ -60,12 +60,9 @@ export LOSS_TYPE="Huber" #"Huber" "Cauchy"
 export LOSS_LIMIT="0.1"
 
 # COV SAMPLING PARS
-export covar_sampling="True"
-export covar_samples_per_axis="3"
-export covar_sampling_scale="4"
+export covar_sampling="False"
 
-
-pars="--range-res ${range_res} --sequence ${SEQUENCE} --radar_ccw ${radar_ccw} --soft_constraint ${soft_constraint} --disable_compensate ${disable_compensate} --cost_type ${cost_type} --submap_scan_size ${submap_scan_size} --registered_min_keyframe_dist ${registered_min_keyframe_dist} --res ${res} --k_strongest ${kstrong} --bag_path ${BAG_FILE_PATH} --est_directory ${est_dir} --gt_directory ${gt_dir} --job_nr 1 --z-min ${zmin} --loss_type ${LOSS_TYPE} --loss_limit ${LOSS_LIMIT}  --weight_intensity ${weight_intensity} --method ${EVALUATION_description} --weight_option ${weight_option} --dataset ${dataset} --store_graph true --save_radar_img true --covar_sampling ${covar_sampling} --covar_samples_per_axis ${covar_samples_per_axis} --covar_sampling_scale ${covar_sampling_scale}"
+pars="--range-res ${range_res} --sequence ${SEQUENCE} --radar_ccw ${radar_ccw} --soft_constraint ${soft_constraint} --disable_compensate ${disable_compensate} --cost_type ${cost_type} --submap_scan_size ${submap_scan_size} --registered_min_keyframe_dist ${registered_min_keyframe_dist} --res ${res} --k_strongest ${kstrong} --bag_path ${BAG_FILE_PATH} --est_directory ${est_dir} --gt_directory ${gt_dir} --job_nr 1 --z-min ${zmin} --loss_type ${LOSS_TYPE} --loss_limit ${LOSS_LIMIT}  --weight_intensity ${weight_intensity} --method ${EVALUATION_description} --weight_option ${weight_option} --dataset ${dataset} --store_graph true --save_radar_img true --covar_sampling ${covar_sampling}"
 echo "|||||Estimating odometry with parameters: ${pars}||||"
 roslaunch cfear_radarodometry vis.launch&
 rosrun cfear_radarodometry offline_odometry ${pars} #>/dev/null

--- a/launch/oxford/run_sequence_save_odom
+++ b/launch/oxford/run_sequence_save_odom
@@ -55,7 +55,7 @@ export radar_ccw="false" #False for oxford, otherwise true
 export soft_constraint="false"
 export disable_compensate="false"
 export dataset="oxford"
-export LOSS_TYPE="Huber"
+export LOSS_TYPE="Huber" #"Huber" "Cauchy" 
 export LOSS_LIMIT="0.1"
 
 

--- a/launch/oxford/run_sequence_save_odom
+++ b/launch/oxford/run_sequence_save_odom
@@ -2,8 +2,7 @@
 
 killall rviz
 
-#SEQUENCE="2019-01-10-12-32-52-radar-oxford-10k"
-SEQUENCE="2019-01-17-13-26-39-radar-oxford-10k"
+SEQUENCE="2019-01-10-12-32-52-radar-oxford-10k"
 current_date=`date '+%Y-%m-%d_%H:%M'`
 EVALUATION_description="cfear-x"
 

--- a/launch/oxford/run_sequence_save_odom
+++ b/launch/oxford/run_sequence_save_odom
@@ -2,7 +2,8 @@
 
 killall rviz
 
-SEQUENCE="2019-01-10-12-32-52-radar-oxford-10k"
+#SEQUENCE="2019-01-10-12-32-52-radar-oxford-10k"
+SEQUENCE="2019-01-17-13-26-39-radar-oxford-10k"
 current_date=`date '+%Y-%m-%d_%H:%M'`
 EVALUATION_description="cfear-x"
 
@@ -58,8 +59,13 @@ export dataset="oxford"
 export LOSS_TYPE="Huber" #"Huber" "Cauchy" 
 export LOSS_LIMIT="0.1"
 
+# COV SAMPLING PARS
+export covar_sampling="True"
+export covar_samples_per_axis="3"
+export covar_sampling_scale="4"
 
-pars="--range-res ${range_res} --sequence ${SEQUENCE} --radar_ccw ${radar_ccw} --soft_constraint ${soft_constraint} --disable_compensate ${disable_compensate} --cost_type ${cost_type} --submap_scan_size ${submap_scan_size} --registered_min_keyframe_dist ${registered_min_keyframe_dist} --res ${res} --k_strongest ${kstrong} --bag_path ${BAG_FILE_PATH} --est_directory ${est_dir} --gt_directory ${gt_dir} --job_nr 1 --z-min ${zmin} --loss_type ${LOSS_TYPE} --loss_limit ${LOSS_LIMIT}  --weight_intensity ${weight_intensity} --method ${EVALUATION_description} --weight_option ${weight_option} --dataset ${dataset} --store_graph true --save_radar_img true"
+
+pars="--range-res ${range_res} --sequence ${SEQUENCE} --radar_ccw ${radar_ccw} --soft_constraint ${soft_constraint} --disable_compensate ${disable_compensate} --cost_type ${cost_type} --submap_scan_size ${submap_scan_size} --registered_min_keyframe_dist ${registered_min_keyframe_dist} --res ${res} --k_strongest ${kstrong} --bag_path ${BAG_FILE_PATH} --est_directory ${est_dir} --gt_directory ${gt_dir} --job_nr 1 --z-min ${zmin} --loss_type ${LOSS_TYPE} --loss_limit ${LOSS_LIMIT}  --weight_intensity ${weight_intensity} --method ${EVALUATION_description} --weight_option ${weight_option} --dataset ${dataset} --store_graph true --save_radar_img true --covar_sampling ${covar_sampling} --covar_samples_per_axis ${covar_samples_per_axis} --covar_sampling_scale ${covar_sampling_scale}"
 echo "|||||Estimating odometry with parameters: ${pars}||||"
 roslaunch cfear_radarodometry vis.launch&
 rosrun cfear_radarodometry offline_odometry ${pars} #>/dev/null

--- a/src/cfear_radarodometry/n_scan_normal.cpp
+++ b/src/cfear_radarodometry/n_scan_normal.cpp
@@ -426,6 +426,15 @@ bool n_scan_normal_reg::GetCovariance(Matrix6d &Cov){
     return true;
   }
 }
+
+bool n_scan_normal_reg::GetCovarianceScaler(double &cov_scale){
+    //Cov should be scaled by num. of residuals and score (Andrea Censi 2007, (3))
+    if(summary_.num_residuals_reduced-summary_.num_parameters_reduced==0) return false;
+
+    cov_scale = summary_.final_cost/(summary_.num_residuals_reduced-summary_.num_parameters_reduced);
+    return true;
+}
+
 bool n_scan_normal_reg::SolveOptimizationProblem(){
 
   CHECK(problem_ != nullptr);

--- a/src/cfear_radarodometry/n_scan_normal.cpp
+++ b/src/cfear_radarodometry/n_scan_normal.cpp
@@ -417,8 +417,8 @@ bool n_scan_normal_reg::GetCovariance(Matrix6d &Cov){
     if(summary_.num_residuals_reduced-summary_.num_parameters_reduced==0) return false;
     Eigen::MatrixXd cmat = 30*(summary_.final_cost/(summary_.num_residuals_reduced-summary_.num_parameters_reduced))
             * Eigen::Map<Eigen::Matrix<double,3,3>>(covariance_xx);
-    cout << "Covariance scaling: " << 30.0*(summary_.final_cost/(summary_.num_residuals_reduced-summary_.num_parameters_reduced))
-         << endl;
+    //  cout << "Covariance scaling: " << 30.0*(summary_.final_cost/(summary_.num_residuals_reduced-summary_.num_parameters_reduced))
+    //       << endl;
 
     // The original way by Daniel:
     // Eigen::MatrixXd cmat =  2.0 * Eigen::Map<Eigen::Matrix<double,3,3> >(covariance_xx); // Magic constat based on data

--- a/src/cfear_radarodometry/n_scan_normal.cpp
+++ b/src/cfear_radarodometry/n_scan_normal.cpp
@@ -113,7 +113,8 @@ bool n_scan_normal_reg::Register(std::vector<MapNormalPtr>& scans, std::vector<E
     //  FOr visualization only
     if(success)
       for(size_t i = 0 ; i<n_scans ; i++)
-        Tsrc[i] = vectorToAffine3d(parameters[i]);
+          Tsrc[i] = vectorToAffine3d(parameters[i]);
+
     double current_score = summary_.final_cost;
     const double rel_improvement = (prev_score-current_score)/prev_score;
     const Eigen::Vector2d trans_diff(parameters.back()[0] - prev_par[0],parameters.back()[1] - prev_par[1]);
@@ -407,7 +408,16 @@ bool n_scan_normal_reg::GetCovariance(Matrix6d &Cov){
   else{
     double covariance_xx[3 * 3];
     covariance.GetCovarianceBlock(v, v, covariance_xx);
-    Eigen::MatrixXd cmat = 10*Eigen::Map<Eigen::Matrix<double,3,3> >(covariance_xx);
+    //DONE BUT IT IS BAD: Should be scaled by num. of residuals and score (Andrea Censi 2007, (3))
+    if(summary_.num_residuals_reduced-summary_.num_parameters_reduced==0) return false;
+    Eigen::MatrixXd cmat = 30*(summary_.final_cost/(summary_.num_residuals_reduced-summary_.num_parameters_reduced))
+            * Eigen::Map<Eigen::Matrix<double,3,3>>(covariance_xx);
+    cout << "Covariance scaling: " << 30.0*(summary_.final_cost/(summary_.num_residuals_reduced-summary_.num_parameters_reduced))
+         << endl;
+
+    // The original way by Daniel:
+    // Eigen::MatrixXd cmat =  2.0 * Eigen::Map<Eigen::Matrix<double,3,3> >(covariance_xx); // Magic constat based on data
+
     Cov = Eigen::Matrix<double,6,6>::Identity();
     Cov.block<2,2>(0,0) = cmat.block<2,2>(0,0);
     Cov(5,5) = cmat(2,2);

--- a/src/cfear_radarodometry/odometrykeyframefuser.cpp
+++ b/src/cfear_radarodometry/odometrykeyframefuser.cpp
@@ -20,7 +20,7 @@ visualization_msgs::Marker GetDefault(){
   return m;
 }
 
-OdometryKeyframeFuser::OdometryKeyframeFuser(const Parameters& pars, bool disable_callback) : par(pars), nh_("~"), generator(std::default_random_engine()){
+OdometryKeyframeFuser::OdometryKeyframeFuser(const Parameters& pars, bool disable_callback) : par(pars), nh_("~") {
   assert (!par.input_points_topic.empty() && !par.scan_registered_latest_topic.empty() && !par.scan_registered_keyframe_topic.empty() && !par.odom_latest_topic.empty() && !par.odom_keyframe_topic.empty() );
   assert(par.res>0.05 && par.submap_scan_size>=1 );
   //radar_reg =

--- a/src/cfear_radarodometry/odometrykeyframefuser.cpp
+++ b/src/cfear_radarodometry/odometrykeyframefuser.cpp
@@ -329,7 +329,9 @@ void OdometryKeyframeFuser::processFrame(pcl::PointCloud<pcl::PointXYZI>::Ptr& c
                   cov_sampled.block<2, 2>(0, 0) = covariance_3x3.block<2, 2>(0, 0);
                   cov_sampled(5, 5) = covariance_3x3(2, 2);
                   cov_sampled(0, 5) = covariance_3x3(0, 2);
+                  cov_sampled(1, 5) = covariance_3x3(1, 2);
                   cov_sampled(5, 0) = covariance_3x3(2, 0);
+                  cov_sampled(5, 1) = covariance_3x3(2, 1);
               }
               else cov_sampled_success = false;
           }
@@ -338,11 +340,11 @@ void OdometryKeyframeFuser::processFrame(pcl::PointCloud<pcl::PointXYZI>::Ptr& c
 
   }
 
-  //VK: Here the Cov. estimation ends
   if(par.estimate_cov_by_sampling && cov_sampled_success){
       cov_current = cov_sampled;
       cov_vek.back() = cov_sampled;
   }
+  //VK: Here the Cov. estimation ends
 
 
   MapPointNormal::PublishMap("/current_normals", Pcurrent, Tcurrent, par.odometry_link_id,-1,0.5);

--- a/src/cfear_radarodometry/odometrykeyframefuser.cpp
+++ b/src/cfear_radarodometry/odometrykeyframefuser.cpp
@@ -152,23 +152,9 @@ void OdometryKeyframeFuser::processFrame(pcl::PointCloud<pcl::PointXYZI>::Ptr& c
 
   std::vector<Matrix6d> cov_vek;
   Covariance cov_sampled;
-  bool cov_sampled_success = true;
   std::vector<CFEAR_Radarodometry::MapNormalPtr> scans_vek;
   std::vector<Eigen::Affine3d> T_vek;
   ros::Time t1 = ros::Time::now();
-
-  // VK TESTING: Incrementally add noise to the cloud and observe how it deteriorates the odometry
-//  double noise_sigma_max = 10.0;
-//  double noise_mean = 0.0;
-//  double noise_sigma = (3.0 / 8600.0) * double(frame_nr_) + 0.0000000001;
-//  std::normal_distribution<double> distribution(noise_mean,noise_sigma);
-//
-//  for(auto && p : cloud->points){
-//    p.x += distribution(generator);
-//    p.y += distribution(generator);
-//  }
-
-  // VK TESTING END
 
   CFEAR_Radarodometry::MapNormalPtr Pcurrent = CFEAR_Radarodometry::MapNormalPtr(new MapPointNormal(cloud, par.res, Eigen::Vector2d(0,0), par.weight_intensity_, par.use_raw_pointcloud));
 
@@ -179,17 +165,6 @@ void OdometryKeyframeFuser::processFrame(pcl::PointCloud<pcl::PointXYZI>::Ptr& c
   else
     Tguess = T_prev;
 
-  // VK Testing Tguess noise
-//  Eigen::Affine3d noise_T = Eigen::Affine3d::Identity();
-//  //noise_T.translation() = Eigen::Vector3d(distribution(generator),distribution(generator),0.0);
-//  //Eigen::AngleAxisd rot(distribution(generator)*0.1, Eigen::Vector3d(0.0,0.0,1.0));
-//  Eigen::AngleAxisd rot(noise_sigma*0.1, Eigen::Vector3d(0.0,0.0,1.0));
-//  noise_T.linear() = rot.toRotationMatrix();
-//
-//
-//  Tguess = Tguess * noise_T;
-//  std::cout << noise_T.matrix() << std::endl;
-  // VK Testing Tguess end
 
   if(keyframes_.empty()){
     scan_ = RadarScan(Eigen::Affine3d::Identity(), Eigen::Affine3d::Identity(), cloud_peaks, cloud, Pcurrent, t);
@@ -222,130 +197,13 @@ void OdometryKeyframeFuser::processFrame(pcl::PointCloud<pcl::PointXYZI>::Ptr& c
     Tcurrent = Tguess; //Insane acceleration and speed, lets use the guess.
   Tmot = T_prev.inverse()*Tcurrent;
 
-  // VK: Cost sampling around the best solution for the better covariance estimation
-  if(par.estimate_cov_by_sampling) {
-      string path;
-      std::ofstream cov_samples_file;
-
-      if(par.cov_samples_to_file_as_well){
-          path = par.cov_sampling_file_directory + string("/cov_samples_") + std::to_string(nr_callbacks_) + string(".csv");
-          cov_samples_file.open(path);
+  // Try to approximate the covariance by the cost-sampling approach
+  if(par.estimate_cov_by_sampling){
+      if(approximateCovarianceBySampling(scans_vek, T_vek, cov_sampled)){ // if success, cov_sampled contains valid data
+          cov_current = cov_sampled;
+          cov_vek.back() = cov_sampled;
       }
-
-      double xy_sample_range = par.cov_sampling_xy_range*0.5; // sampling in x and y axis around the estimated pose
-      double theta_range = par.cov_sampling_yaw_range*0.5;  // sampling on the yaw axis plus minus
-      unsigned int number_of_steps_per_axis = par.cov_sampling_samples_per_axis;
-      unsigned int number_of_samples = number_of_steps_per_axis*number_of_steps_per_axis*number_of_steps_per_axis;
-
-      Eigen::Affine3d sample_T = Eigen::Affine3d::Identity();
-      double sample_cost = 0;  // return of the getCost function
-      std::vector<double> residuals; // return of the getCost function
-      Eigen::VectorXd samples_x_values(number_of_samples);
-      Eigen::VectorXd samples_y_values(number_of_samples);
-      Eigen::VectorXd samples_yaw_values(number_of_samples);
-      Eigen::VectorXd samples_cost_values(number_of_samples);
-
-      std::vector<double> xy_samples = linspace<double>(-xy_sample_range, xy_sample_range, number_of_steps_per_axis);
-      std::vector<double> theta_samples = linspace<double>(-theta_range, theta_range, number_of_steps_per_axis);
-
-      // Sample the cost function according to the settings, optionally dump the samples into a file
-      int vector_pointer = 0;
-      for (int theta_sample_id = 0; theta_sample_id < number_of_steps_per_axis; theta_sample_id++) {
-          for (int x_sample_id = 0; x_sample_id < number_of_steps_per_axis; x_sample_id++) {
-              for (int y_sample_id = 0; y_sample_id < number_of_steps_per_axis; y_sample_id++) {
-
-                  sample_T.translation() = Eigen::Vector3d(xy_samples[x_sample_id],
-                                                           xy_samples[y_sample_id],
-                                                           0.0) + Tcurrent.translation();
-                  sample_T.linear() = Eigen::AngleAxisd(theta_samples[theta_sample_id],
-                                                        Eigen::Vector3d(0.0, 0.0, 1.0)) * Tcurrent.linear();
-
-                  T_vek.back() = sample_T;
-                  //!!!! Make sure we think about calling explicitly Huber or None or Cauchy here
-                  radar_reg->GetCost(scans_vek, T_vek, sample_cost, residuals);
-
-                  samples_x_values[vector_pointer] = xy_samples[x_sample_id];
-                  samples_y_values[vector_pointer] = xy_samples[y_sample_id];
-                  samples_yaw_values[vector_pointer] = theta_samples[theta_sample_id];
-                  samples_cost_values[vector_pointer] = sample_cost;
-                  vector_pointer ++;
-
-                  if(par.cov_samples_to_file_as_well) {
-                      cov_samples_file << xy_samples[x_sample_id] << " " << xy_samples[y_sample_id] <<
-                                       " " << theta_samples[theta_sample_id] << " " << sample_cost << std::endl;
-                  }
-              }
-          }
-      }
-      if(cov_samples_file.is_open()) cov_samples_file.close();
-
-      //Find the approximating quadratic function by linear least squares
-      // f(x,y,z) = ax^2 + by^2 + cz^2 + dxy + eyz + fzx + gx+ hy + iz + j
-      // A = [x^2, y^2, z^2, xy, yz, zx, x, y, z, 1]
-      Eigen::MatrixXd A(number_of_samples, 10);
-      A << samples_x_values.array().square().matrix(),
-           samples_y_values.array().square().matrix(),
-           samples_yaw_values.array().square().matrix(),
-           (samples_x_values.array()*samples_y_values.array()).matrix(),
-           (samples_y_values.array()*samples_yaw_values.array()).matrix(),
-           (samples_yaw_values.array()*samples_x_values.array()).matrix(),
-           samples_x_values,
-           samples_y_values,
-           samples_yaw_values,
-           Eigen::MatrixXd::Ones(number_of_samples,1);
-
-      Eigen::VectorXd quad_func_coefs = A.bdcSvd(Eigen::ComputeThinU | Eigen::ComputeThinV).solve(samples_cost_values);
-
-      // With the coefficients, we can contruct the Hessian matrix (constant for a given function)
-      Eigen::Matrix3d hessian_matrix;
-      hessian_matrix << 2*quad_func_coefs[0],   quad_func_coefs[3],   quad_func_coefs[5],
-                          quad_func_coefs[3], 2*quad_func_coefs[1],   quad_func_coefs[4],
-                          quad_func_coefs[5],   quad_func_coefs[4], 2*quad_func_coefs[2];
-
-      // We need to check if the approximating function is convex (all eigs positive, we don't went the zero eigs either)
-      Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> eigensolver(hessian_matrix);
-      Eigen::Vector3d eigValues;
-      Eigen::Matrix3d covariance_3x3;
-
-      if (eigensolver.info() != Eigen::Success) {
-          cov_sampled_success = false;
-          std::cout << "Covariance sampling warning: Eigenvalues search failed." << std::endl;
-      }
-      else{
-          eigValues = eigensolver.eigenvalues();
-          if(eigValues[0] <= 0.0 || eigValues[1] <= 0.0 || eigValues[2] <= 0.0){
-              cov_sampled_success = false;
-              std::cout << "Covariance sampling warning: Quadratic approximation not convex. Sampling will not be used for this scan." << std::endl;
-          }
-          else{
-              // Compute the covariance from the hessian and scale by the score
-              double score_scale = 1.0;
-              if(radar_reg->GetCovarianceScaler(score_scale)) {
-
-                  covariance_3x3 = 2.0 * hessian_matrix.inverse() * score_scale * par.cov_sampling_covariance_scaler;
-
-                  //We need to construct the full 6DOF cov matrix
-                  cov_sampled = Eigen::Matrix<double, 6, 6>::Identity();
-                  cov_sampled.block<2, 2>(0, 0) = covariance_3x3.block<2, 2>(0, 0);
-                  cov_sampled(5, 5) = covariance_3x3(2, 2);
-                  cov_sampled(0, 5) = covariance_3x3(0, 2);
-                  cov_sampled(1, 5) = covariance_3x3(1, 2);
-                  cov_sampled(5, 0) = covariance_3x3(2, 0);
-                  cov_sampled(5, 1) = covariance_3x3(2, 1);
-              }
-              else cov_sampled_success = false;
-          }
-
-      }
-
   }
-
-  if(par.estimate_cov_by_sampling && cov_sampled_success){
-      cov_current = cov_sampled;
-      cov_vek.back() = cov_sampled;
-  }
-  //VK: Here the Cov. estimation ends
-
 
   MapPointNormal::PublishMap("/current_normals", Pcurrent, Tcurrent, par.odometry_link_id,-1,0.5);
   pcl::PointCloud<pcl::PointXYZI> cld_latest = FormatScanMsg(*cloud, Tcurrent);
@@ -382,7 +240,7 @@ void OdometryKeyframeFuser::processFrame(pcl::PointCloud<pcl::PointXYZI>::Ptr& c
 
     frame_nr_++;
     scan_ = RadarScan(Tcurrent, TprevMot, cloud_peaks, cloud, Pcurrent, t);
-    AddToGraph(keyframes_, scan_, Eigen::Matrix<double,6,6>::Identity());
+    AddToGraph(keyframes_, scan_, cov_current);
     AddToReference(keyframes_,scan_, par.submap_scan_size);
     updated = true;
 
@@ -396,6 +254,129 @@ void OdometryKeyframeFuser::processFrame(pcl::PointCloud<pcl::PointXYZI>::Ptr& c
   CFEAR_Radarodometry::timing.Document("publish_etc", ToMs(t4-t3));
   T_prev = Tcurrent;
 
+}
+
+bool OdometryKeyframeFuser::approximateCovarianceBySampling(std::vector<CFEAR_Radarodometry::MapNormalPtr> &scans_vek,
+                                                            const std::vector<Eigen::Affine3d> &T_vek,
+                                                            Covariance &cov_sampled){
+    bool cov_sampled_success = true;
+    string path;   // for dumping samples to a file
+    std::ofstream cov_samples_file;
+
+    std::vector<Eigen::Affine3d> T_vek_copy(T_vek);
+    Eigen::Affine3d T_best_guess = T_vek_copy.back();
+
+    if(par.cov_samples_to_file_as_well){
+        path = par.cov_sampling_file_directory + string("/cov_samples_") + std::to_string(nr_callbacks_) + string(".csv");
+        cov_samples_file.open(path);
+    }
+
+    double xy_sample_range = par.cov_sampling_xy_range*0.5; // sampling in x and y axis around the estimated pose
+    double theta_range = par.cov_sampling_yaw_range*0.5;  // sampling on the yaw axis plus minus
+    unsigned int number_of_steps_per_axis = par.cov_sampling_samples_per_axis;
+    unsigned int number_of_samples = number_of_steps_per_axis*number_of_steps_per_axis*number_of_steps_per_axis;
+
+    Eigen::Affine3d sample_T = Eigen::Affine3d::Identity();
+    double sample_cost = 0;  // return of the getCost function
+    std::vector<double> residuals; // return of the getCost function
+    Eigen::VectorXd samples_x_values(number_of_samples);
+    Eigen::VectorXd samples_y_values(number_of_samples);
+    Eigen::VectorXd samples_yaw_values(number_of_samples);
+    Eigen::VectorXd samples_cost_values(number_of_samples);
+
+    std::vector<double> xy_samples = linspace<double>(-xy_sample_range, xy_sample_range, number_of_steps_per_axis);
+    std::vector<double> theta_samples = linspace<double>(-theta_range, theta_range, number_of_steps_per_axis);
+
+    // Sample the cost function according to the settings, optionally dump the samples into a file
+    int vector_pointer = 0;
+    for (int theta_sample_id = 0; theta_sample_id < number_of_steps_per_axis; theta_sample_id++) {
+        for (int x_sample_id = 0; x_sample_id < number_of_steps_per_axis; x_sample_id++) {
+            for (int y_sample_id = 0; y_sample_id < number_of_steps_per_axis; y_sample_id++) {
+
+                sample_T.translation() = Eigen::Vector3d(xy_samples[x_sample_id],
+                                                         xy_samples[y_sample_id],
+                                                         0.0) + T_best_guess.translation();
+                sample_T.linear() = Eigen::AngleAxisd(theta_samples[theta_sample_id],
+                                                      Eigen::Vector3d(0.0, 0.0, 1.0)) * T_best_guess.linear();
+
+                T_vek_copy.back() = sample_T;
+                radar_reg->GetCost(scans_vek, T_vek_copy, sample_cost, residuals);
+
+                samples_x_values[vector_pointer] = xy_samples[x_sample_id];
+                samples_y_values[vector_pointer] = xy_samples[y_sample_id];
+                samples_yaw_values[vector_pointer] = theta_samples[theta_sample_id];
+                samples_cost_values[vector_pointer] = sample_cost;
+                vector_pointer ++;
+
+                if(par.cov_samples_to_file_as_well) {
+                    cov_samples_file << xy_samples[x_sample_id] << " " << xy_samples[y_sample_id] <<
+                                     " " << theta_samples[theta_sample_id] << " " << sample_cost << std::endl;
+                }
+            }
+        }
+    }
+    if(cov_samples_file.is_open()) cov_samples_file.close();
+
+    //Find the approximating quadratic function by linear least squares
+    // f(x,y,z) = ax^2 + by^2 + cz^2 + dxy + eyz + fzx + gx+ hy + iz + j
+    // A = [x^2, y^2, z^2, xy, yz, zx, x, y, z, 1]
+    Eigen::MatrixXd A(number_of_samples, 10);
+    A << samples_x_values.array().square().matrix(),
+            samples_y_values.array().square().matrix(),
+            samples_yaw_values.array().square().matrix(),
+            (samples_x_values.array()*samples_y_values.array()).matrix(),
+            (samples_y_values.array()*samples_yaw_values.array()).matrix(),
+            (samples_yaw_values.array()*samples_x_values.array()).matrix(),
+            samples_x_values,
+            samples_y_values,
+            samples_yaw_values,
+            Eigen::MatrixXd::Ones(number_of_samples,1);
+
+    Eigen::VectorXd quad_func_coefs = A.bdcSvd(Eigen::ComputeThinU | Eigen::ComputeThinV).solve(samples_cost_values);
+
+    // With the coefficients, we can contruct the Hessian matrix (constant for a given function)
+    Eigen::Matrix3d hessian_matrix;
+    hessian_matrix << 2*quad_func_coefs[0],   quad_func_coefs[3],   quad_func_coefs[5],
+            quad_func_coefs[3], 2*quad_func_coefs[1],   quad_func_coefs[4],
+            quad_func_coefs[5],   quad_func_coefs[4], 2*quad_func_coefs[2];
+
+    // We need to check if the approximating function is convex (all eigs positive, we don't went the zero eigs either)
+    Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> eigensolver(hessian_matrix);
+    Eigen::Vector3d eigValues;
+    Eigen::Matrix3d covariance_3x3;
+
+    if (eigensolver.info() != Eigen::Success) {
+        cov_sampled_success = false;
+        std::cout << "Covariance sampling warning: Eigenvalues search failed." << std::endl;
+    }
+    else{
+        eigValues = eigensolver.eigenvalues();
+        if(eigValues[0] <= 0.0 || eigValues[1] <= 0.0 || eigValues[2] <= 0.0){
+            cov_sampled_success = false;
+            std::cout << "Covariance sampling warning: Quadratic approximation not convex. Sampling will not be used for this scan." << std::endl;
+        }
+        else{
+            // Compute the covariance from the hessian and scale by the score
+            double score_scale = 1.0;
+            if(radar_reg->GetCovarianceScaler(score_scale)) {
+
+                covariance_3x3 = 2.0 * hessian_matrix.inverse() * score_scale * par.cov_sampling_covariance_scaler;
+
+                //We need to construct the full 6DOF cov matrix
+                cov_sampled = Eigen::Matrix<double, 6, 6>::Identity();
+                cov_sampled.block<2, 2>(0, 0) = covariance_3x3.block<2, 2>(0, 0);
+                cov_sampled(5, 5) = covariance_3x3(2, 2);
+                cov_sampled(0, 5) = covariance_3x3(0, 2);
+                cov_sampled(1, 5) = covariance_3x3(1, 2);
+                cov_sampled(5, 0) = covariance_3x3(2, 0);
+                cov_sampled(5, 1) = covariance_3x3(2, 1);
+            }
+            else cov_sampled_success = false;
+        }
+
+    }
+
+    return cov_sampled_success;
 }
 
 void OdometryKeyframeFuser::pointcloudCallback(const sensor_msgs::PointCloud2::ConstPtr& msg_in){

--- a/src/cfear_radarodometry/odometrykeyframefuser.cpp
+++ b/src/cfear_radarodometry/odometrykeyframefuser.cpp
@@ -1,4 +1,7 @@
 #include "cfear_radarodometry/odometrykeyframefuser.h"
+#include <Eigen/Dense>
+#include <Eigen/Eigenvalues>
+
 namespace CFEAR_Radarodometry {
 
 visualization_msgs::Marker GetDefault(){
@@ -139,7 +142,6 @@ pcl::PointCloud<pcl::PointXYZI> OdometryKeyframeFuser::FormatScanMsg(pcl::PointC
 
 void OdometryKeyframeFuser::processFrame(pcl::PointCloud<pcl::PointXYZI>::Ptr& cloud, pcl::PointCloud<pcl::PointXYZI>::Ptr& cloud_peaks, const ros::Time& t) {
 
-
   ros::Time t0 = ros::Time::now();
   Eigen::Affine3d TprevMot(Tmot);
   if(par.compensate){
@@ -149,6 +151,8 @@ void OdometryKeyframeFuser::processFrame(pcl::PointCloud<pcl::PointXYZI>::Ptr& c
 
 
   std::vector<Matrix6d> cov_vek;
+  Covariance cov_sampled;
+  bool cov_sampled_success = true;
   std::vector<CFEAR_Radarodometry::MapNormalPtr> scans_vek;
   std::vector<Eigen::Affine3d> T_vek;
   ros::Time t1 = ros::Time::now();
@@ -167,7 +171,6 @@ void OdometryKeyframeFuser::processFrame(pcl::PointCloud<pcl::PointXYZI>::Ptr& c
   // VK TESTING END
 
   CFEAR_Radarodometry::MapNormalPtr Pcurrent = CFEAR_Radarodometry::MapNormalPtr(new MapPointNormal(cloud, par.res, Eigen::Vector2d(0,0), par.weight_intensity_, par.use_raw_pointcloud));
-
 
   ros::Time t2 = ros::Time::now();
   Eigen::Affine3d Tguess;
@@ -188,7 +191,7 @@ void OdometryKeyframeFuser::processFrame(pcl::PointCloud<pcl::PointXYZI>::Ptr& c
 //  std::cout << noise_T.matrix() << std::endl;
   // VK Testing Tguess end
 
-    if(keyframes_.empty()){
+  if(keyframes_.empty()){
     scan_ = RadarScan(Eigen::Affine3d::Identity(), Eigen::Affine3d::Identity(), cloud_peaks, cloud, Pcurrent, t);
     AddToGraph(keyframes_, scan_, Eigen::Matrix<double,6,6>::Identity());
     updated = true;
@@ -219,31 +222,37 @@ void OdometryKeyframeFuser::processFrame(pcl::PointCloud<pcl::PointXYZI>::Ptr& c
     Tcurrent = Tguess; //Insane acceleration and speed, lets use the guess.
   Tmot = T_prev.inverse()*Tcurrent;
 
-  // VK: Cost sampling around the best solution
-  //std::vector<uint> interesting_samples {215, 218, 263, 270, 1913, 1918};
-  //if(std::find(interesting_samples.begin(), interesting_samples.end(), nr_callbacks_) != interesting_samples.end()) {
-  if(nr_callbacks_ >= 100 && nr_callbacks_ <= 500) {
-      string path = string("/tmp/cfear_out/cov_samples_") + std::to_string(nr_callbacks_) + string(".csv");
-      std::ofstream cov_samples_file(path);
+  // VK: Cost sampling around the best solution for the better covariance estimation
+  if(par.estimate_cov_by_sampling) {
+      string path;
+      std::ofstream cov_samples_file;
 
-      double sample_cost = 0;
-      std::vector<double> residuals;
-      double xy_sample_range = 0.2; // sampling in all directions
-      double theta_range = 0.01745;  // plus minus
-      int number_of_steps = 11;
+      if(par.cov_samples_to_file_as_well){
+          path = par.cov_sampling_file_directory + string("/cov_samples_") + std::to_string(nr_callbacks_) + string(".csv");
+          cov_samples_file.open(path);
+      }
+
+      double xy_sample_range = par.cov_sampling_xy_range*0.5; // sampling in x and y axis around the estimated pose
+      double theta_range = par.cov_sampling_yaw_range*0.5;  // sampling on the yaw axis plus minus
+      unsigned int number_of_steps_per_axis = par.cov_sampling_samples_per_axis;
+      unsigned int number_of_samples = number_of_steps_per_axis*number_of_steps_per_axis*number_of_steps_per_axis;
+
       Eigen::Affine3d sample_T = Eigen::Affine3d::Identity();
+      double sample_cost = 0;  // return of the getCost function
+      std::vector<double> residuals; // return of the getCost function
+      Eigen::VectorXd samples_x_values(number_of_samples);
+      Eigen::VectorXd samples_y_values(number_of_samples);
+      Eigen::VectorXd samples_yaw_values(number_of_samples);
+      Eigen::VectorXd samples_cost_values(number_of_samples);
 
-      std::vector<double> xy_samples = linspace<double>(-xy_sample_range, xy_sample_range, number_of_steps);
-      std::vector<double> theta_samples = linspace<double>(-theta_range, theta_range, number_of_steps);
-      //std::cout << "SAMPLING COST Function ###################################################" << std::endl;
-      for (int theta_sample_id = 0; theta_sample_id < number_of_steps; theta_sample_id++) {
-          //std::cout << "Theta offset: " << theta_samples[theta_sample_id] << " #################" << std::endl;
-          //for (int y_sample_id = 0; y_sample_id < number_of_steps; y_sample_id++) {
-          //    std::cout << xy_samples[y_sample_id] << " ";
-          //}
-          //std::cout << std::endl;
-          for (int x_sample_id = 0; x_sample_id < number_of_steps; x_sample_id++) {
-              for (int y_sample_id = 0; y_sample_id < number_of_steps; y_sample_id++) {
+      std::vector<double> xy_samples = linspace<double>(-xy_sample_range, xy_sample_range, number_of_steps_per_axis);
+      std::vector<double> theta_samples = linspace<double>(-theta_range, theta_range, number_of_steps_per_axis);
+
+      // Sample the cost function according to the settings, optionally dump the samples into a file
+      int vector_pointer = 0;
+      for (int theta_sample_id = 0; theta_sample_id < number_of_steps_per_axis; theta_sample_id++) {
+          for (int x_sample_id = 0; x_sample_id < number_of_steps_per_axis; x_sample_id++) {
+              for (int y_sample_id = 0; y_sample_id < number_of_steps_per_axis; y_sample_id++) {
 
                   sample_T.translation() = Eigen::Vector3d(xy_samples[x_sample_id],
                                                            xy_samples[y_sample_id],
@@ -252,23 +261,88 @@ void OdometryKeyframeFuser::processFrame(pcl::PointCloud<pcl::PointXYZI>::Ptr& c
                                                         Eigen::Vector3d(0.0, 0.0, 1.0)) * Tcurrent.linear();
 
                   T_vek.back() = sample_T;
+                  //!!!! Make sure we think about calling explicitly Huber or None or Cauchy here
                   radar_reg->GetCost(scans_vek, T_vek, sample_cost, residuals);
 
-          //        std::cout << sample_cost << " ";
-                  cov_samples_file << xy_samples[x_sample_id] << " " << xy_samples[y_sample_id] <<
-                                      " " << theta_samples[theta_sample_id] << " " << sample_cost << std::endl;
+                  samples_x_values[vector_pointer] = xy_samples[x_sample_id];
+                  samples_y_values[vector_pointer] = xy_samples[y_sample_id];
+                  samples_yaw_values[vector_pointer] = theta_samples[theta_sample_id];
+                  samples_cost_values[vector_pointer] = sample_cost;
+                  vector_pointer ++;
 
+                  if(par.cov_samples_to_file_as_well) {
+                      cov_samples_file << xy_samples[x_sample_id] << " " << xy_samples[y_sample_id] <<
+                                       " " << theta_samples[theta_sample_id] << " " << sample_cost << std::endl;
+                  }
               }
-          //    std::cout << "  || " << xy_samples[x_sample_id] << std::endl;
           }
       }
-      //std::cout << "########################################################################" << std::endl;
-      cov_samples_file.close();
+      if(cov_samples_file.is_open()) cov_samples_file.close();
+
+      //Find the approximating quadratic function by linear least squares
+      // f(x,y,z) = ax^2 + by^2 + cz^2 + dxy + eyz + fzx + gx+ hy + iz + j
+      // A = [x^2, y^2, z^2, xy, yz, zx, x, y, z, 1]
+      Eigen::MatrixXd A(number_of_samples, 10);
+      A << samples_x_values.array().square().matrix(),
+           samples_y_values.array().square().matrix(),
+           samples_yaw_values.array().square().matrix(),
+           (samples_x_values.array()*samples_y_values.array()).matrix(),
+           (samples_y_values.array()*samples_yaw_values.array()).matrix(),
+           (samples_yaw_values.array()*samples_x_values.array()).matrix(),
+           samples_x_values,
+           samples_y_values,
+           samples_yaw_values,
+           Eigen::MatrixXd::Ones(number_of_samples,1);
+
+      Eigen::VectorXd quad_func_coefs = A.bdcSvd(Eigen::ComputeThinU | Eigen::ComputeThinV).solve(samples_cost_values);
+
+      // With the coefficients, we can contruct the Hessian matrix (constant for a given function)
+      Eigen::Matrix3d hessian_matrix;
+      hessian_matrix << 2*quad_func_coefs[0],   quad_func_coefs[3],   quad_func_coefs[5],
+                          quad_func_coefs[3], 2*quad_func_coefs[1],   quad_func_coefs[4],
+                          quad_func_coefs[5],   quad_func_coefs[4], 2*quad_func_coefs[2];
+
+      // We need to check if the approximating function is convex (all eigs positive, we don't went the zero eigs either)
+      Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> eigensolver(hessian_matrix);
+      Eigen::Vector3d eigValues;
+      Eigen::Matrix3d covariance_3x3;
+
+      if (eigensolver.info() != Eigen::Success) {
+          cov_sampled_success = false;
+          std::cout << "Covariance sampling warning: Eigenvalues search failed." << std::endl;
+      }
+      else{
+          eigValues = eigensolver.eigenvalues();
+          if(eigValues[0] <= 0.0 || eigValues[1] <= 0.0 || eigValues[2] <= 0.0){
+              cov_sampled_success = false;
+              std::cout << "Covariance sampling warning: Quadratic approximation not convex. Sampling will not be used for this scan." << std::endl;
+          }
+          else{
+              // Compute the covariance from the hessian and scale by the score
+              double score_scale = 1.0;
+              if(radar_reg->GetCovarianceScaler(score_scale)) {
+
+                  covariance_3x3 = 2.0 * hessian_matrix.inverse() * score_scale * par.cov_sampling_covariance_scaler;
+
+                  //We need to construct the full 6DOF cov matrix
+                  cov_sampled = Eigen::Matrix<double, 6, 6>::Identity();
+                  cov_sampled.block<2, 2>(0, 0) = covariance_3x3.block<2, 2>(0, 0);
+                  cov_sampled(5, 5) = covariance_3x3(2, 2);
+                  cov_sampled(0, 5) = covariance_3x3(0, 2);
+                  cov_sampled(5, 0) = covariance_3x3(2, 0);
+              }
+              else cov_sampled_success = false;
+          }
+
+      }
+
   }
 
-
-
-
+  //VK: Here the Cov. estimation ends
+  if(par.estimate_cov_by_sampling && cov_sampled_success){
+      cov_current = cov_sampled;
+      cov_vek.back() = cov_sampled;
+  }
 
 
   MapPointNormal::PublishMap("/current_normals", Pcurrent, Tcurrent, par.odometry_link_id,-1,0.5);

--- a/src/offline_odometry.cpp
+++ b/src/offline_odometry.cpp
@@ -170,7 +170,7 @@ void ReadOptions(const int argc, char**argv, OdometryKeyframeFuser::Parameters& 
         ("loss_type", po::value<std::string>()->default_value("Huber"), "robust loss function eg. Huber Caunchy, None")
         ("loss_limit", po::value<double>()->default_value(0.1), "loss limit")
         ("covar_scale", po::value<double>()->default_value(1), "covar scale")// Please fix combined parameter
-        ("covar_sampling", po::value<bool>()->default_value(true), "Covar. by cost sampling")
+        ("covar_sampling", po::value<bool>()->default_value(false), "Covar. by cost sampling")
         ("covar_sample_save", po::value<bool>()->default_value(false), "Dump cost samples to a file")
         ("covar_sample_dir", po::value<std::string>()->default_value("/tmp/cfear_out"), "Where to save the cost samples")
         ("covar_XY_sample_range", po::value<double>()->default_value(0.4), "Sampling range on the x and y axes")

--- a/src/offline_odometry.cpp
+++ b/src/offline_odometry.cpp
@@ -170,6 +170,13 @@ void ReadOptions(const int argc, char**argv, OdometryKeyframeFuser::Parameters& 
         ("loss_type", po::value<std::string>()->default_value("Huber"), "robust loss function eg. Huber Caunchy, None")
         ("loss_limit", po::value<double>()->default_value(0.1), "loss limit")
         ("covar_scale", po::value<double>()->default_value(1), "covar scale")// Please fix combined parameter
+        ("covar_sampling", po::value<bool>()->default_value(true), "Covar. by cost sampling")
+        ("covar_sample_save", po::value<bool>()->default_value(false), "Dump cost samples to a file")
+        ("covar_sample_dir", po::value<std::string>()->default_value("/tmp/cfear_out"), "Where to save the cost samples")
+        ("covar_XY_sample_range", po::value<double>()->default_value(0.4), "Sampling range on the x and y axes")
+        ("covar_yaw_sample_range", po::value<double>()->default_value(0.0043625), "Sampling range on the yaw axis")
+        ("covar_samples_per_axis", po::value<int>()->default_value(3), "Num. of samples per axis for covar. sampling")
+        ("covar_sampling_scale", po::value<double>()->default_value(4), "Sampled covar. scale")
         ("regularization", po::value<double>()->default_value(1), "regularization")
         ("est_directory", po::value<std::string>()->default_value(""), "output folder of estimated trajectory")
         ("gt_directory", po::value<std::string>()->default_value(""), "output folder of ground truth trajectory")
@@ -184,6 +191,7 @@ void ReadOptions(const int argc, char**argv, OdometryKeyframeFuser::Parameters& 
         ("store_graph", po::value<bool>()->default_value(false),"store_graph")
         ("save_radar_img", po::value<bool>()->default_value(false),"save_radar_img")
         ("bag_path", po::value<std::string>()->default_value("/home/daniel/rosbag/oxford-eval-sequences/2019-01-10-12-32-52-radar-oxford-10k/radar/2019-01-10-12-32-52-radar-oxford-10k.bag"), "bag file to open");
+
 
     po::variables_map vm;
     store(parse_command_line(argc, argv, desc), vm);
@@ -207,6 +215,20 @@ void ReadOptions(const int argc, char**argv, OdometryKeyframeFuser::Parameters& 
       par.loss_limit_ = vm["loss_limit"].as<double>();
     if (vm.count("covar_scale"))
       par.covar_scale_ = vm["covar_scale"].as<double>();
+    if (vm.count("covar_sampling"))
+        par.estimate_cov_by_sampling = vm["covar_sampling"].as<bool>();
+    if (vm.count("covar_sample_save"))
+        par.cov_samples_to_file_as_well = vm["covar_sample_save"].as<bool>();
+    if (vm.count("covar_sample_dir"))
+        par.cov_sampling_file_directory = vm["covar_sample_dir"].as<std::string>();
+    if (vm.count("covar_XY_sample_range"))
+        par.cov_sampling_xy_range = vm["covar_XY_sample_range"].as<double>();
+    if (vm.count("covar_yaw_sample_range"))
+        par.cov_sampling_yaw_range = vm["covar_yaw_sample_range"].as<double>();
+    if (vm.count("covar_samples_per_axis"))
+        par.cov_sampling_samples_per_axis = vm["covar_samples_per_axis"].as<int>();
+    if (vm.count("covar_sampling_scale"))
+        par.cov_sampling_covariance_scaler = vm["covar_sampling_scale"].as<double>();
     if (vm.count("regularization"))
       par.regularization_ = vm["regularization"].as<double>();
     if (vm.count("submap_scan_size"))
@@ -243,10 +265,10 @@ void ReadOptions(const int argc, char**argv, OdometryKeyframeFuser::Parameters& 
       rad_par.window_size = vm["covar_scale"].as<double>();
 
 
-    p.save_radar_img = vm["save_radar_img"].as<bool>();;
+    p.save_radar_img = vm["save_radar_img"].as<bool>();
     rad_par.filter_type_ = Str2filter(vm["filter-type"].as<std::string>());
-    par.store_graph = vm["store_graph"].as<bool>();;
-    par.weight_intensity_ = vm["weight_intensity"].as<bool>();;
+    par.store_graph = vm["store_graph"].as<bool>();
+    par.weight_intensity_ = vm["weight_intensity"].as<bool>();
     par.compensate = !vm["disable_compensate"].as<bool>();
     par.use_guess = true; //vm["soft_constraint"].as<bool>();
     par.soft_constraint = false; // soft constraint is rarely useful, this is changed for testing of initi // vm["soft_constraint"].as<bool>();


### PR DESCRIPTION
This branch adds the cost function sampling for better covar estimation. By default, the sampling is off, since it increases the computational load. BUT, BEWARE: It looks like the implementation used up to now was adding unit matrices for covariance into the simple_graph, not the ceres-based result (which goes into the odom messages etc.). Therefore, running cfear even with the new sampling off, the results may change