### PR TITLE
correct residual size in soft constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ The method generalizes across diverse environments without the need for returnin
 
 
 ### October 2023 - RadaRays
-[RadaRays](https://arxiv.org/pdf/2310.03505.pdf) is a method for simulating radar data, released as a gazebo plugin. Mock et al. were able to simulate radar scans from a prior lidar map, and accurately estimate radar odometry in the MulRan dataset. The estimated trajectories closely resemble the odometry estimated from real radar data.
+[RadaRays](https://arxiv.org/pdf/2310.03505.pdf) is a method for simulating radar data, released as a gazebo plugin. Mock et al. were able to simulate radar scans by raytracing within a lidar map, and accurately estimate radar odometry in the MulRan dataset. The estimated trajectories closely resemble the odometry estimated from real radar data. The [code](https://github.com/uos/radarays_ros) and a [gazebo radar plugin](https://github.com/uos/radarays_gazebo_plugins) for the project has been released.
 
 
 

--- a/include/cfear_radarodometry/n_scan_normal.h
+++ b/include/cfear_radarodometry/n_scan_normal.h
@@ -279,7 +279,7 @@ public:
   }
   static ceres::CostFunction* Create(
       const Eigen::Vector3d& target_mean, const Eigen::Matrix3d& tar_sqrt_information, double alpha) {
-    return new ceres::AutoDiffCostFunction<mahalanobisDistanceError,1, 3>(new mahalanobisDistanceError (target_mean, tar_sqrt_information, alpha));
+    return new ceres::AutoDiffCostFunction<mahalanobisDistanceError,3, 3>(new mahalanobisDistanceError (target_mean, tar_sqrt_information, alpha));
   }
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   private:

--- a/src/offline_odometry.cpp
+++ b/src/offline_odometry.cpp
@@ -271,7 +271,7 @@ void ReadOptions(const int argc, char**argv, OdometryKeyframeFuser::Parameters& 
     par.weight_intensity_ = vm["weight_intensity"].as<bool>();
     par.compensate = !vm["disable_compensate"].as<bool>();
     par.use_guess = true; //vm["soft_constraint"].as<bool>();
-    par.soft_constraint = false; // soft constraint is rarely useful, this is changed for testing of initi // vm["soft_constraint"].as<bool>();
+    par.soft_constraint = vm["soft_constraint"].as<bool>();
     par.radar_ccw = vm["radar_ccw"].as<bool>();
 
 }


### PR DESCRIPTION
Re-enabled imposing a soft constraint on the estimate based on the motion prior. Fixed an error in the ceres residual implementation: Size of the residual is 3 (x,y,th) instead of 1.